### PR TITLE
Add status-page for new containers.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,7 +44,7 @@
                     <h4>2. REDCap Data File</h4>
 
                     <div class="form-group">
-                        <p>Attach an data file exported from your REDCap project page.</p>
+                        <p>Attach a data file exported from your REDCap project page.</p>
 
                         <div class="alert alert-warning">
 				<strong>Note.</strong>

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+    <head>
+        <link href="../../bootstrap.min.css" rel="stylesheet">
+    </head>
+
+    <body>
+        <div class="container">
+            <div class="page header">
+	        <h2 id="cid">Container: {{ cid }}</h2>
+                <p id="status">{{ status }}</p>
+            </div>
+            <div class="row">
+	        <div class="col-md-6">
+                    <h4>StdOut:</h4>
+		    <pre class="pre-scrollable" id="stdout"> {{ out }} </pre>
+	        </div>
+		<div class="col-md-6">
+                    <h4>StdErr:</h4>
+		    <pre class="pre-scrollable" id="stderr">{{ err }} </pre>
+	        </div>
+            </div>
+        </div>
+        <script>
+            (function() {
+              var url = '{{ url }}'
+              var checkContainer = function(url) {
+                 var xmlhttp = new XMLHttpRequest();
+
+                 // Set the state change handler.
+                 xmlhttp.onreadystatechange = function() {
+                   if (xmlhttp.readyState === 4 && xmlhttp.status === 200) {
+                     var data = JSON.parse(xmlhttp.responseText);
+                     document.getElementById('status').innerHTML = data.status;
+                     document.getElementById('stdout').innerHTML = data.out;
+                     document.getElementById('stderr').innerHTML = data.err;
+                     document.getElementById('cid').innerHTML = 'Container: ' + data.cid;
+                   }
+                 };
+
+                 xmlhttp.open('POST', url, true);
+                 xmlhttp.send();
+              }
+
+              // Start the Interval
+              setInterval(function() {
+                checkContainer(url);
+              }, 5000);
+
+            })();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The status page uses AJAX to poll HaaS for the container's logs and status.
At this commit, the status page will always load when a container is created,
but in the future should appear only when the build fails, or while it is building

Signed-off-by: James Swanick swanijam@gmail.com
